### PR TITLE
linkGRASS(): don't override existing GRASSdb region & projection settings

### DIFF
--- a/R/linkGRASS.R
+++ b/R/linkGRASS.R
@@ -156,6 +156,7 @@ linkGRASS7 <- function(x = NULL,
                          override = TRUE
       ) 
       if(!quiet) return(rgrass7::gmeta())
+      return()
     }
     
     ### if not do the temp linking procedure


### PR DESCRIPTION
Should fix #22 . For existing databases, will now return `NULL` with `quiet = TRUE`.