### PR TITLE
Add pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^tic\.R$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,32 @@
+# DO NOT CHANGE THE CODE BELOW
+before_install:
+  - R -q -e 'if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")'
+  - R -q -e 'if (!requireNamespace("curl", quietly = TRUE)) install.packages("curl")'
+  - R -q -e 'remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
+install: R -q -e 'tic::install()'
+after_install: R -q -e 'tic::after_install()'
+before_script: R -q -e 'tic::before_script()'
+script: R -q -e 'tic::script()'
+after_success: R -q -e 'tic::after_success()'
+after_failure: R -q -e 'tic::after_failure()'
+before_deploy: R -q -e 'tic::before_deploy()'
+deploy:
+  provider: script
+  script: R -q -e 'tic::deploy()'
+  on:
+    all_branches: true
+after_deploy: R -q -e 'tic::after_deploy()'
+after_script: R -q -e 'tic::after_script()'
+# DO NOT CHANGE THE CODE ABOVE
 
-# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+# Custom parts:
+
+# Header
 language: r
-sudo: false
+dist: bionic
 cache: packages
-warnings_are_errors: false
-
-#- oldrel # breaks on lacking isFALSE#/isTRUE
-
+latex: true
 
 addons:
   apt:
@@ -22,3 +42,10 @@ addons:
       - libgdal-dev
       - netcdf-bin 
       - libudunits2-dev
+
+env:
+  global:
+  - _R_CHECK_FORCE_SUGGESTS_=false
+  - MAKEFLAGS="-j 2"
+  - BUILD_PKGDOWN=true
+  - _R_CHECK_TESTS_NLINES_=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,4 @@ env:
   global:
   - _R_CHECK_FORCE_SUGGESTS_=false
   - MAKEFLAGS="-j 2"
-  - BUILD_PKGDOWN=true
   - _R_CHECK_TESTS_NLINES_=0

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
+# link2GI
+
 [![Travis-CI Build Status](https://travis-ci.org/r-spatial/link2GI.svg?branch=master)](https://travis-ci.org/r-spatial/link2GI)
 <a href="https://cran.r-project.org/web/checks/check_results_link2GI.html"><img border="0" src="http://www.r-pkg.org/badges/version/link2GI" alt="CRAN version"></a>
 ![](https://cranlogs.r-pkg.org/badges/grand-total/link2GI?color=green)
-
 [![License](https://img.shields.io/badge/license-GPL%20%28%3E=%203%29-lightgrey.svg?style=flat)](http://www.gnu.org/licenses/gpl-3.0.html)
 
-# link2GI
+Package website: [release]( https://r-spatial.github.io/link2GI) | [dev](https://r-spatial.github.io/link2GI/dev)
 
 `link2GI` provide some functions which make it a bit easier to connect straightforward the common open source GI software packages to the R-biotop. It supports both the use of wrapper packages and the direct API-use via system calls. It focuses on `Linux` and `WindowsX` operating systems but nevertheless it should also work with `OSX`.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,1 +1,7 @@
-destination: docs
+url: https://r-spatial.github.io/link2GI
+
+development:
+  mode: auto
+  version_label: default
+  version_tooltip: "Version"
+

--- a/tic.R
+++ b/tic.R
@@ -1,0 +1,3 @@
+do_package_checks(error_on = "warning")
+
+do_pkgdown()


### PR DESCRIPTION
To make everything work, please do

1. 
```r
remotes::install_github("ropenscilabs/travis@travis-com")
travis::use_travis_deploy()
```

2. Set the Github pages branch under "Settings" to `gh-pages`

If `travis::use_travis_deploy()` throws permission errors, ask for admin permission for the `link2GI` repo.

All of this builds a pkgdown site for both release and dev version (dev version at `[...]/dev`. Release version will reflect the current change of the pkg for the respective cran release.
