### PR TITLE
linkGRASS7(): new method to extract sf proj4string

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,14 @@ URL: https://github.com/r-spatial/link2GI/, https://r-spatial.github.io/link2GI/
 BugReports: https://github.com/r-spatial/link2GI/issues/
 License: GPL (>= 3) | file LICENSE
 Depends: R (>= 3.5.0)
-Imports: devtools, R.utils,roxygen2,sf,stringr,raster, methods
+Imports: 
+  devtools, 
+  R.utils,
+  roxygen2,
+  sf,
+  stringr,
+  raster, 
+  methods
 SystemRequirements: GNU make 
 RoxygenNote: 7.0.2
 Suggests: knitr, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,12 +17,12 @@ Imports:
   devtools, 
   R.utils,
   roxygen2,
-  sf,
+  sf (>= 0.9),
   stringr,
   raster, 
   methods
 SystemRequirements: GNU make 
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Suggests: knitr, 
           rmarkdown,
           rgdal,

--- a/R/linkGRASS.R
+++ b/R/linkGRASS.R
@@ -187,7 +187,7 @@ linkGRASS7 <- function(x = NULL,
           xmin <- corner[1]
           ymax <- corner[4]
           ymin <- corner[2]
-          proj4 <-  unlist(sf::st_crs(x)[2])
+          proj4 <-  sf::st_crs(x)$proj4string
           if (!is.null(resolution)) resolution<- resolution
           else resolution <- "1"
         } else {

--- a/man/rgb.Rd
+++ b/man/rgb.Rd
@@ -4,7 +4,9 @@
 \name{rgb}
 \alias{rgb}
 \title{RGB ortho-image from an arbitray Marburg Open Forest (MOF) plot}
-\format{\code{"raster::raster"}}
+\format{
+\code{"raster::raster"}
+}
 \description{
 Example data set containing a RGB ortho-image of a small plot sampled in the Maburg University Forest aka Marburg Open Forest (MOF). The resolution is 10 cm, projection ETRS89 UTM32
 }


### PR DESCRIPTION
Should fix #38 

As `sf::st_crs()` is not used anywhere else in the package than in this PR's changed lines, I accordingly added a minimal version for `sf` dependency.

I have just tested this once, with a temporary GRASS project, and it worked.