### PR TITLE
searchGRASSX(): a general approach to finding the grass78 folder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
   raster, 
   methods
 SystemRequirements: GNU make 
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests: knitr, 
           rmarkdown,
           rgdal,

--- a/R/grass7Control.R
+++ b/R/grass7Control.R
@@ -325,11 +325,12 @@ searchGRASSW <- function(DL = "C:",
 
 
 
-#'@title Search recursivly valid 'GRASS GIS' installation(s) at a given 'Linux' mount point
+#'@title Return attributes of valid 'GRASS GIS' installation(s) in 'Linux'
 #'@name searchGRASSX
-#'@description Search for valid 'GRASS GIS' installations at a given 'Linux' mount point
-#'@param MP default is /usr
-#'@return A dataframe containing 'GRASS GIS' binary folder(s), version name(s) and installation type code(s)
+#'@description Searches recursively for valid 'GRASS GIS' installations at a given 'Linux' mount point.
+#'Returns attributes for each installation.
+#'@param MP default is /usr. This is the directory from which the grass executable file is searched, i.e. one executable for each GRASS installation on the system.
+#'@return A dataframe containing 'GRASS GIS' binary folder(s) (i.e. where the individual GRASS commands are installed), version name(s) and installation type code(s)
 #'@param quiet boolean  switch for supressing console messages default is TRUEs
 
 #'@author Chris Reudenbach
@@ -527,17 +528,22 @@ checkGisdbase <- function(x = NULL , gisdbase = NULL, location = NULL, gisdbase_
 }
 
 
-#'@title Search recursivly existing 'GRASS GIS' installation(s) at a given drive/mountpoint 
+#'@title Return attributes of valid 'GRASS GIS' installation(s) on the system
 #'@name findGRASS
-#'@description  Provides an  list of valid 'GRASS GIS' installation(s) 
-#'on your 'Windows' system. There is a major difference between osgeo4W and 
-#'stand_alone installations. The functions trys to find all valid 
+#'@description  Provides a list of valid 'GRASS GIS' installation(s) 
+#'on your system. There is a major difference between osgeo4W and 
+#'stand_alone installations. The functions tries to find all valid 
 #'installations by analysing the calling batch scripts.
-#'@param searchLocation drive letter to be searched, for Windows systems default For Windows Systems it is mandatory to use Capitel letters with colon only
+#'@param searchLocation location to be searched for the grass executable, 
+#'i.e. one executable for each GRASS installation on the system.
+#'For Windows systems
+#'it is mandatory to include an uppercase Windows drive letter and a colon.
+#' Default For Windows Systems 
 #' is \code{C:}, for Linux systems default is \code{/usr}.
 #'@param ver_select boolean default is FALSE. If there is more than one 'SAGA GIS' installation and \code{ver_select} = TRUE the user can select interactively the preferred 'SAGA GIS' version 
 #'@param quiet boolean  switch for supressing console messages default is TRUE
-#'@return A dataframe with the 'GRASS GIS' root folder(s), version name(s) and 
+#'@return A dataframe with the 'GRASS GIS' binary folder(s) (i.e. where the 
+#'individual GRASS commands are installed), version name(s) and 
 #'installation type code(s)
 #'@author Chris Reudenbach
 #'@export findGRASS

--- a/R/grass7Control.R
+++ b/R/grass7Control.R
@@ -365,14 +365,11 @@ searchGRASSX <- function(MP = "/usr",quiet =TRUE){
       ver_char <- substr(ver_char, gregexpr(pattern = '"', ver_char)[[1]][1] + 1, nchar(ver_char) - 1)
       cmd <- grep(readLines(raw_GRASS[[i]]),pattern = 'CMD_NAME = "',value = TRUE)
       cmd <- substr(cmd, gregexpr(pattern = '"', cmd)[[1]][1] + 1, nchar(cmd) - 1)
-      #rootdir<- grep(readLines(raw_GRASS[[i]]),pattern = 'GISBASE = os.path.normpath',value = TRUE)        
-      #rootdir <- substr(rootdir[2], gregexpr(pattern = '"', rootdir)[[1]][1] + 1, nchar(rootdir) - 1)
       
-      grasslib <-system2("find", paste(MP," ! -readable -prune -o -type f -executable -iname 'v.clean' -print"),stdout = TRUE,stderr = FALSE)
+      rootdir<- grep(readLines(raw_GRASS[[i]]),pattern = 'GISBASE = os.path.normpath',value = TRUE)
+      root_dir <- substr(rootdir[2], gregexpr(pattern = '"', rootdir[2])[[1]][1] + 1, nchar(rootdir[2]) - 2)
       
-      rd = file.exists(grasslib)  
-      if (rd)  root_dir <- substr(grasslib, 1, nchar(grasslib) - 12)
-      else root_dir =  "/opt/grass"
+      if (!file.exists(root_dir)) root_dir  <-  "/opt/grass"
     }
       if (rg[[i]][lengths(rg)] != "grass78") {
         

--- a/man/findGRASS.Rd
+++ b/man/findGRASS.Rd
@@ -2,12 +2,16 @@
 % Please edit documentation in R/grass7Control.R
 \name{findGRASS}
 \alias{findGRASS}
-\title{Search recursivly existing 'GRASS GIS' installation(s) at a given drive/mountpoint}
+\title{Return attributes of valid 'GRASS GIS' installation(s) on the system}
 \usage{
 findGRASS(searchLocation = "default", ver_select = FALSE, quiet = TRUE)
 }
 \arguments{
-\item{searchLocation}{drive letter to be searched, for Windows systems default For Windows Systems it is mandatory to use Capitel letters with colon only
+\item{searchLocation}{location to be searched for the grass executable, 
+i.e. one executable for each GRASS installation on the system.
+For Windows systems
+it is mandatory to include an uppercase Windows drive letter and a colon.
+Default For Windows Systems 
 is \code{C:}, for Linux systems default is \code{/usr}.}
 
 \item{ver_select}{boolean default is FALSE. If there is more than one 'SAGA GIS' installation and \code{ver_select} = TRUE the user can select interactively the preferred 'SAGA GIS' version}
@@ -15,13 +19,14 @@ is \code{C:}, for Linux systems default is \code{/usr}.}
 \item{quiet}{boolean  switch for supressing console messages default is TRUE}
 }
 \value{
-A dataframe with the 'GRASS GIS' root folder(s), version name(s) and 
+A dataframe with the 'GRASS GIS' binary folder(s) (i.e. where the 
+individual GRASS commands are installed), version name(s) and 
 installation type code(s)
 }
 \description{
-Provides an  list of valid 'GRASS GIS' installation(s) 
-on your 'Windows' system. There is a major difference between osgeo4W and 
-stand_alone installations. The functions trys to find all valid 
+Provides a list of valid 'GRASS GIS' installation(s) 
+on your system. There is a major difference between osgeo4W and 
+stand_alone installations. The functions tries to find all valid 
 installations by analysing the calling batch scripts.
 }
 \examples{

--- a/man/searchGRASSX.Rd
+++ b/man/searchGRASSX.Rd
@@ -2,20 +2,21 @@
 % Please edit documentation in R/grass7Control.R
 \name{searchGRASSX}
 \alias{searchGRASSX}
-\title{Search recursivly valid 'GRASS GIS' installation(s) at a given 'Linux' mount point}
+\title{Return attributes of valid 'GRASS GIS' installation(s) in 'Linux'}
 \usage{
 searchGRASSX(MP = "/usr", quiet = TRUE)
 }
 \arguments{
-\item{MP}{default is /usr}
+\item{MP}{default is /usr. This is the directory from which the grass executable file is searched, i.e. one executable for each GRASS installation on the system.}
 
 \item{quiet}{boolean  switch for supressing console messages default is TRUEs}
 }
 \value{
-A dataframe containing 'GRASS GIS' binary folder(s), version name(s) and installation type code(s)
+A dataframe containing 'GRASS GIS' binary folder(s) (i.e. where the individual GRASS commands are installed), version name(s) and installation type code(s)
 }
 \description{
-Search for valid 'GRASS GIS' installations at a given 'Linux' mount point
+Searches recursively for valid 'GRASS GIS' installations at a given 'Linux' mount point.
+Returns attributes for each installation.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Fixes #44.

I reactivated your (outcommented) parsing of the GISBASE setting and worked a little further on that; it seems the most general approach IMO.

Before, `searchGRASSX()` tried to locate the `grass78` folder by looking for `v.clean` in the `MP` argument (this is the `searchLocation` argument of `findGRASS()` that is passed to `searchGRASSX()`). However this will only work if `MP` comprises both the `grass78` executable and the `grass78` folder (which works for the default `/usr,` which however is slow).

With current approach, it only needs a `searchLocation` where the executable can be found, which seems to be the intended behaviour. Regarding the latter, I also tried to clarify this a little more in the documentation of `findGRASS()` and `searchGRASSX()`.

Please check whether I've understood what is the intended behaviour. Anyhow it now runs again as:

```r
> link2GI::findGRASS(searchLocation = "/usr/bin")
           instDir version installation_type
1 /usr/lib/grass78   7.8.2           grass78
```