### PR TITLE
link/find/param/searchGRASS: /usr/bin as default on non-Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ addons:
       - libgdal-dev
       - netcdf-bin 
       - libudunits2-dev
+      - libfribidi-dev
 
 env:
   global:

--- a/R/grass7Control.R
+++ b/R/grass7Control.R
@@ -4,7 +4,7 @@
 #'@details During the rsession you will have full access to GRASS7 GIS via the \code{rgrass7} wrappe. Additionally you may use also use the API calls of GRASS7 via the command line.
 #'@param set_default_GRASS7 default = NULL will force a search for 'GRASS GIS' You may provide a valid combination as 
 #'                                    c("/usr/lib/grass74","7.4.1","grass74")
-#'@param MP mount point to be searched. default is "usr"
+#'@param MP mount point to be searched. default is "/usr/bin"
 #'@param quiet boolean  switch for supressing console messages default is TRUE
 #'@param ver_select if TRUE you must interactivley selcect between alternative installations
 #'@export paramGRASSx
@@ -23,7 +23,7 @@
 #' }
 
 paramGRASSx <- function(set_default_GRASS7=NULL, 
-                        MP = "/usr",
+                        MP = "/usr/bin",
                         ver_select = FALSE, 
                         quiet =TRUE){
   if (ver_select =='T') ver_select <- TRUE
@@ -339,15 +339,15 @@ searchGRASSW <- function(DL = "C:",
 #'
 #'@examples
 #' \dontrun{
-#' # get all valid 'GRASS GIS' installation folders in the /usr directory (typical location)
-#' searchGRASSX("/usr")
+#' # get all valid 'GRASS GIS' installation folders in the /usr/bin directory (typical location)
+#' searchGRASSX("/usr/bin")
 #' 
 #' # get all valid 'GRASS GIS' installation folders in the home directory
 #' searchGRASSX("~/")
 #' }
 
-searchGRASSX <- function(MP = "/usr",quiet =TRUE){
-  if (MP=="default") MP <- "/usr"
+searchGRASSX <- function(MP = "/usr/bin",quiet =TRUE){
+  if (MP=="default") MP <- "/usr/bin"
   raw_GRASS <- system2("find", paste(MP," ! -readable -prune -o -type f -executable -iname 'grass??' -print"),stdout = TRUE,stderr = FALSE)
   
   
@@ -539,7 +539,7 @@ checkGisdbase <- function(x = NULL , gisdbase = NULL, location = NULL, gisdbase_
 #'For Windows systems
 #'it is mandatory to include an uppercase Windows drive letter and a colon.
 #' Default For Windows Systems 
-#' is \code{C:}, for Linux systems default is \code{/usr}.
+#' is \code{C:}, for Linux systems default is \code{/usr/bin}.
 #'@param ver_select boolean default is FALSE. If there is more than one 'SAGA GIS' installation and \code{ver_select} = TRUE the user can select interactively the preferred 'SAGA GIS' version 
 #'@param quiet boolean  switch for supressing console messages default is TRUE
 #'@return A dataframe with the 'GRASS GIS' binary folder(s) (i.e. where the 
@@ -564,7 +564,7 @@ findGRASS <- function(searchLocation = "default",
       link = link2GI::searchGRASSW(DL = searchLocation)  
     else return(cat("You are running Windows - Please choose a suitable searchLocation argument that MUST include a Windows drive letter and colon"))
   } else {
-    if (searchLocation=="default") searchLocation <- "/usr"
+    if (searchLocation=="default") searchLocation <- "/usr/bin"
     if (grepl(searchLocation,pattern = ":"))  return(cat("You are running Linux - please choose a suitable searchLocation argument"))
     else link = link2GI::searchGRASSX(MP = searchLocation)
   }

--- a/R/linkGRASS.R
+++ b/R/linkGRASS.R
@@ -131,7 +131,7 @@ linkGRASS7 <- function(x = NULL,
     grass <- paramGRASSw(default_GRASS7,search_path,ver_select)
   } else {
     if (use_home) home <- Sys.getenv("HOME")
-    if (is.null(search_path)) search_path <- "/usr"
+    if (is.null(search_path)) search_path <- "/usr/bin"
     grass <- paramGRASSx(default_GRASS7,search_path,ver_select)
   }
   if (grass[[1]][1] != FALSE) {

--- a/man/findGRASS.Rd
+++ b/man/findGRASS.Rd
@@ -12,7 +12,7 @@ i.e. one executable for each GRASS installation on the system.
 For Windows systems
 it is mandatory to include an uppercase Windows drive letter and a colon.
 Default For Windows Systems 
-is \code{C:}, for Linux systems default is \code{/usr}.}
+is \code{C:}, for Linux systems default is \code{/usr/bin}.}
 
 \item{ver_select}{boolean default is FALSE. If there is more than one 'SAGA GIS' installation and \code{ver_select} = TRUE the user can select interactively the preferred 'SAGA GIS' version}
 

--- a/man/paramGRASSx.Rd
+++ b/man/paramGRASSx.Rd
@@ -6,7 +6,7 @@
 \usage{
 paramGRASSx(
   set_default_GRASS7 = NULL,
-  MP = "/usr",
+  MP = "/usr/bin",
   ver_select = FALSE,
   quiet = TRUE
 )
@@ -15,7 +15,7 @@ paramGRASSx(
 \item{set_default_GRASS7}{default = NULL will force a search for 'GRASS GIS' You may provide a valid combination as 
 c("/usr/lib/grass74","7.4.1","grass74")}
 
-\item{MP}{mount point to be searched. default is "usr"}
+\item{MP}{mount point to be searched. default is "/usr/bin"}
 
 \item{ver_select}{if TRUE you must interactivley selcect between alternative installations}
 

--- a/man/searchGRASSX.Rd
+++ b/man/searchGRASSX.Rd
@@ -4,7 +4,7 @@
 \alias{searchGRASSX}
 \title{Return attributes of valid 'GRASS GIS' installation(s) in 'Linux'}
 \usage{
-searchGRASSX(MP = "/usr", quiet = TRUE)
+searchGRASSX(MP = "/usr/bin", quiet = TRUE)
 }
 \arguments{
 \item{MP}{default is /usr. This is the directory from which the grass executable file is searched, i.e. one executable for each GRASS installation on the system.}
@@ -20,8 +20,8 @@ Returns attributes for each installation.
 }
 \examples{
 \dontrun{
-# get all valid 'GRASS GIS' installation folders in the /usr directory (typical location)
-searchGRASSX("/usr")
+# get all valid 'GRASS GIS' installation folders in the /usr/bin directory (typical location)
+searchGRASSX("/usr/bin")
 
 # get all valid 'GRASS GIS' installation folders in the home directory
 searchGRASSX("~/")


### PR DESCRIPTION
This provides a solution to meet the request in #46. See also https://github.com/r-spatial/link2GI/issues/46#issuecomment-734224835.